### PR TITLE
 Implementation of Withdrawal Tests

### DIFF
--- a/tests/lib.cairo
+++ b/tests/lib.cairo
@@ -40,3 +40,11 @@ mod referral {
 mod liquidation {
     mod test_liquidation;
 }
+
+
+#[cfg(test)]
+mod withdrawal {
+    mod test_withdrawal;
+    mod test_withdrawal_utils;
+    mod test_withdrawal_vault;
+}

--- a/tests/withdrawal/test_withdrawal.cairo
+++ b/tests/withdrawal/test_withdrawal.cairo
@@ -1,2 +1,17 @@
-use satoru::withdrawal::withdrawal;
+use satoru::withdrawal::withdrawal::Withdrawal;
+use starknet::contract_address_const;
 
+#[test]
+fn test_default_withdrawal() {
+    let default_withdrawal: Withdrawal = Default::default();
+    let default_contract_address = contract_address_const::<0>();
+    assert(default_withdrawal.key == 0, 'invalid key');
+    assert(default_withdrawal.market_token_amount == 0, 'invalid market_token_amount');
+    assert(default_withdrawal.min_long_token_amount == 0, 'invalid min long token amount');
+    assert(default_withdrawal.min_short_token_amount == 0, 'invalid min_short_token_amount');
+    assert(default_withdrawal.account == default_contract_address, 'invalid account');
+    assert(default_withdrawal.receiver == default_contract_address, 'invalid receiver');
+    assert(default_withdrawal.callback_contract == default_contract_address, 'invalid callback_contract');
+    assert(default_withdrawal.ui_fee_receiver == default_contract_address, 'invalid ui_fee_receiver');
+    assert(default_withdrawal.market == default_contract_address, 'invalid market');
+}

--- a/tests/withdrawal/test_withdrawal.cairo
+++ b/tests/withdrawal/test_withdrawal.cairo
@@ -1,0 +1,2 @@
+use satoru::withdrawal::withdrawal;
+

--- a/tests/withdrawal/test_withdrawal_utils.cairo
+++ b/tests/withdrawal/test_withdrawal_utils.cairo
@@ -16,7 +16,7 @@ use satoru::oracle::{oracle::{IOracleDispatcher, IOracleDispatcherTrait}, oracle
 use satoru::pricing::{swap_pricing_utils, swap_pricing_utils::SwapFees};
 use satoru::swap::{swap_utils, swap_utils::SwapParams};
 use satoru::utils::{
-    calc, account_utils, error_utils, precision, starknet_utils, span32::Span32,
+    calc, account_utils, error_utils, precision, starknet_utils, span32::{Span32, Array32Trait},
     store_arrays::{StoreContractAddressArray, StoreU256Array}
 };
 use satoru::withdrawal::{
@@ -81,8 +81,8 @@ fn test_create_withdrawal_success() {
     let market = contract_address_const::<0x100>();
         
     // Create empty swap paths
-    let long_token_swap_path = ArrayTrait::<ContractAddress>::new().span32();
-    let short_token_swap_path = ArrayTrait::<ContractAddress>::new().span32();
+    let long_token_swap_path = Array32Trait::<ContractAddress>::span32(@ArrayTrait::new());
+    let short_token_swap_path = Array32Trait::<ContractAddress>::span32(@ArrayTrait::new());
         
     let params = CreateWithdrawalParams {
         receiver,
@@ -127,8 +127,8 @@ fn test_create_withdrawal_insufficient_fee() {
     let market = contract_address_const::<0x100>();
         
     // Create empty swap paths
-    let long_token_swap_path = ArrayTrait::<ContractAddress>::new().span32();
-    let short_token_swap_path = ArrayTrait::<ContractAddress>::new().span32();
+    let long_token_swap_path = Array32Trait::<ContractAddress>::span32(@ArrayTrait::new());
+    let short_token_swap_path = Array32Trait::<ContractAddress>::span32(@ArrayTrait::new());
         
     let params = CreateWithdrawalParams {
         receiver,
@@ -174,8 +174,8 @@ let (data_store, event_emitter, market_token, oracle, withdrawal_vault) = deploy
             callback_contract: contract_address_const::<0x202>(),
             ui_fee_receiver: contract_address_const::<0x203>(),
             market: market,
-            long_token_swap_path: ArrayTrait::<ContractAddress>::new().span32(),
-            short_token_swap_path: ArrayTrait::<ContractAddress>::new().span32(),
+            long_token_swap_path: Array32Trait::<ContractAddress>::span32(@ArrayTrait::new()),
+            short_token_swap_path: Array32Trait::<ContractAddress>::span32(@ArrayTrait::new()),
             market_token_amount: 100000000000000000_u256,
             min_long_token_amount: 50000000000000000_u256,
             min_short_token_amount: 50000000000000000_u256,
@@ -238,13 +238,14 @@ fn test_swap() {
     let key = 0x123;
     let ui_fee_receiver = contract_address_const::<0x203>();
     let min_oracle_block_numbers: Array<u64> = array![2000000_u64, 120000_u64, 100000_u64];
-    let min_oracle_block_numbers: Array<u64> = array![20000000_u64, 12000000_u64, 1000000_u64];
+    let max_oracle_block_numbers: Array<u64> = array![20000000_u64, 12000000_u64, 1000000_u64];
     let keeper = contract_address_const::<0x300>();
     let some_token = contract_address_const::<0x400>();
     let token_in = contract_address_const::<0x200>();
     let receiver = contract_address_const::<0x500>();
     let ui_fee_receiver = contract_address_const::<0x600>();
     let amount_in: u256 = 100000000000_u256;
+    let min_output_amount = 100000000000_u256;
 
     // create execute withdrawal paramas
     let params = ExecuteWithdrawalParams{
@@ -273,11 +274,11 @@ fn test_swap() {
         token_in,
         amount_in,
         swap_path,
-        min_output_amount: 100000000000_u256,
+        min_output_amount,
         receiver,
-        ui_fee_receiver,
+        ui_fee_receiver
     );
 
-    assert!(output_token == token_in, 'invalid token');
-    assert!(output_amount == amount_in, 'invalid amount');
+    assert(output_token == token_in, 'invalid token');
+    assert(output_amount == amount_in, 'invalid amount');
 }

--- a/tests/withdrawal/test_withdrawal_utils.cairo
+++ b/tests/withdrawal/test_withdrawal_utils.cairo
@@ -1,0 +1,283 @@
+use starknet::{ContractAddress, get_block_timestamp, contract_address_const};
+
+// Local imports.
+use satoru::bank::{bank::{IBankDispatcher, IBankDispatcherTrait},};
+use satoru::data::{data_store::{IDataStoreDispatcher, IDataStoreDispatcherTrait}, keys};
+use satoru::callback::callback_utils;
+use satoru::event::{event_emitter::{IEventEmitterDispatcher, IEventEmitterDispatcherTrait}};
+use satoru::fee::fee_utils;
+use satoru::gas::gas_utils;
+use satoru::market::{
+    market::Market, market_token::{IMarketTokenDispatcher, IMarketTokenDispatcherTrait},
+    market_utils, market_utils::MarketPrices
+};
+use satoru::nonce::nonce_utils;
+use satoru::oracle::{oracle::{IOracleDispatcher, IOracleDispatcherTrait}, oracle_utils};
+use satoru::pricing::{swap_pricing_utils, swap_pricing_utils::SwapFees};
+use satoru::swap::{swap_utils, swap_utils::SwapParams};
+use satoru::utils::{
+    calc, account_utils, error_utils, precision, starknet_utils, span32::Span32,
+    store_arrays::{StoreContractAddressArray, StoreU256Array}
+};
+use satoru::withdrawal::{
+    error::WithdrawalError, withdrawal::Withdrawal,
+    withdrawal_vault::{IWithdrawalVaultDispatcher, IWithdrawalVaultDispatcherTrait},
+    withdrawal_utils::{create_withdrawal, cancel_withdrawal, swap, execute_withdrawal, CreateWithdrawalParams, ExecuteWithdrawalParams}
+};
+use satoru::market::market_utils::validate_enabled_market_check;
+use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank};
+
+
+
+
+fn deploy_contracts() -> (
+    IDataStoreDispatcher,
+    IEventEmitterDispatcher,
+    IMarketTokenDispatcher,
+    IOracleDispatcher,
+    IWithdrawalVaultDispatcher
+) {
+    // Deploy mock contracts
+    let role_store_class = declare('RoleStore');
+    let role_store_address = role_store_class.deploy(@ArrayTrait::new()).unwrap();
+    let data_store = declare('DataStore');
+    let data_store_address = data_store.deploy(@array![role_store_address.into()]).unwrap();
+
+    let event_emitter = declare('EventEmitter');
+    let mut calldata = ArrayTrait::new();
+    let event_emitter_address = event_emitter.deploy(@calldata).unwrap();
+
+    let withdrawal_vault = declare('WithdrawalVault');
+    let withdrawal_vault_address = withdrawal_vault.deploy(@array![data_store_address.into(),role_store_address.into(), ]).unwrap();
+
+    let market_token = declare('MarketToken');
+    let market_token_address = market_token.deploy(@array![data_store_address.into(),role_store_address.into()]).unwrap();
+
+    let oracle_store = declare('OracleStore');
+    let oracle_store_address = oracle_store.deploy(@array![role_store_address.into(),event_emitter_address.into()]).unwrap();
+
+    let oracle = declare('Oracle');
+    let oracle_address = oracle.deploy(@array![role_store_address.into(),oracle_store_address.into(), contract_address_const::<0x123>().into()]).unwrap();
+
+    let data_store = IDataStoreDispatcher { contract_address: data_store_address };
+    let event_emitter = IEventEmitterDispatcher { contract_address: event_emitter_address };
+    let oracle = IOracleDispatcher { contract_address: oracle_address };
+    let market_token = IMarketTokenDispatcher { contract_address: market_token_address };
+    let withdrawal_vault = IWithdrawalVaultDispatcher { contract_address: withdrawal_vault_address };
+
+    (data_store, event_emitter, market_token, oracle, withdrawal_vault)
+}
+
+
+#[test]
+fn test_create_withdrawal_success() {
+    let (data_store, event_emitter, market_token, oracle, withdrawal_vault) = deploy_contracts();
+        
+    // Set up test data
+    let account = contract_address_const::<0x200>();
+    let receiver = contract_address_const::<0x201>();
+    let callback_contract = contract_address_const::<0x202>();
+    let ui_fee_receiver = contract_address_const::<0x203>();
+    let market = contract_address_const::<0x100>();
+        
+    // Create empty swap paths
+    let long_token_swap_path = ArrayTrait::<ContractAddress>::new().span32();
+    let short_token_swap_path = ArrayTrait::<ContractAddress>::new().span32();
+        
+    let params = CreateWithdrawalParams {
+        receiver,
+        callback_contract,
+        ui_fee_receiver,
+        market,
+        long_token_swap_path,
+        short_token_swap_path,
+        min_long_token_amount: 50000000000000000_u256,
+        min_short_token_amount: 50000000000000000_u256,
+        execution_fee: 0_u256,
+        callback_gas_limit: 100000_u256,
+    };
+        
+        
+    // Execute function
+    let key = create_withdrawal(
+        IDataStoreDispatcher { contract_address: data_store.contract_address },
+        IEventEmitterDispatcher { contract_address: event_emitter.contract_address },
+        IWithdrawalVaultDispatcher { contract_address: withdrawal_vault.contract_address },
+        account,
+        params
+    );
+        
+    // Verify withdrawal was created
+    let stored_withdrawal = data_store.get_withdrawal(key);
+    assert(stored_withdrawal.account == account, 'Wrong account');
+    assert(stored_withdrawal.receiver == receiver, 'Wrong receiver');
+    assert(stored_withdrawal.market == market, 'Wrong market');
+}
+    
+#[test]
+#[should_panic]
+fn test_create_withdrawal_insufficient_fee() {
+    let (data_store, event_emitter, market_token, oracle, withdrawal_vault) = deploy_contracts();
+        
+    // Set up test data
+    let account = contract_address_const::<0x200>();
+    let receiver = contract_address_const::<0x201>();
+    let callback_contract = contract_address_const::<0x202>();
+    let ui_fee_receiver = contract_address_const::<0x203>();
+    let market = contract_address_const::<0x100>();
+        
+    // Create empty swap paths
+    let long_token_swap_path = ArrayTrait::<ContractAddress>::new().span32();
+    let short_token_swap_path = ArrayTrait::<ContractAddress>::new().span32();
+        
+    let params = CreateWithdrawalParams {
+        receiver,
+        callback_contract,
+        ui_fee_receiver,
+        market,
+        long_token_swap_path,
+        short_token_swap_path,
+        min_long_token_amount: 50000000000000000_u256,
+        min_short_token_amount: 50000000000000000_u256,
+        execution_fee: 1000000000_u256, // Higher than available
+        callback_gas_limit: 100000_u256,
+    };
+        
+        
+        
+    // Should fail due to insufficient fee
+    create_withdrawal(
+        IDataStoreDispatcher { contract_address: data_store.contract_address },
+        IEventEmitterDispatcher { contract_address: event_emitter.contract_address },
+        IWithdrawalVaultDispatcher { contract_address: withdrawal_vault.contract_address },
+        account,
+        params
+    );
+}
+    
+
+    
+#[test]
+fn test_cancel_withdrawal() {
+let (data_store, event_emitter, market_token, oracle, withdrawal_vault) = deploy_contracts();
+        
+    // Create a withdrawal first
+    let account = contract_address_const::<0x200>();
+    let market = contract_address_const::<0x100>();
+    let key = 0x123;
+        
+    // Create and store withdrawal
+    let withdrawal = Withdrawal {
+            key: key,
+            account: account,
+            receiver: contract_address_const::<0x201>(),
+            callback_contract: contract_address_const::<0x202>(),
+            ui_fee_receiver: contract_address_const::<0x203>(),
+            market: market,
+            long_token_swap_path: ArrayTrait::<ContractAddress>::new().span32(),
+            short_token_swap_path: ArrayTrait::<ContractAddress>::new().span32(),
+            market_token_amount: 100000000000000000_u256,
+            min_long_token_amount: 50000000000000000_u256,
+            min_short_token_amount: 50000000000000000_u256,
+            updated_at_block: get_block_timestamp(),
+            execution_fee: 10000000000000000_u256,
+            callback_gas_limit: 100000_u256,
+    };
+        
+    data_store.set_withdrawal(key, withdrawal);
+        
+        
+        
+    // Cancel the withdrawal
+    let keeper = contract_address_const::<0x300>();
+    let mut reason_bytes = ArrayTrait::<felt252>::new();
+        
+    cancel_withdrawal(
+            IDataStoreDispatcher { contract_address: data_store.contract_address },
+            IEventEmitterDispatcher { contract_address: event_emitter.contract_address },
+            IWithdrawalVaultDispatcher { contract_address: withdrawal_vault.contract_address },
+            key,
+            keeper,
+            100000_u256,
+            'TEST_CANCELLATION',
+            reason_bytes
+    );
+        
+        // Verify withdrawal was removed
+    let stored_withdrawal = data_store.get_withdrawal(key);
+    assert(stored_withdrawal.account == Zeroable::zero(), 'Withdrawal not removed');
+}
+    
+#[test]
+#[should_panic]
+fn test_cancel_nonexistent_withdrawal() {
+    let (data_store, event_emitter, market_token, oracle, withdrawal_vault) = deploy_contracts();
+        
+    // Try to cancel a non-existent withdrawal
+    let key = 0x456;
+    let keeper = contract_address_const::<0x300>();
+    let mut reason_bytes = ArrayTrait::<felt252>::new();
+        
+    cancel_withdrawal(
+        IDataStoreDispatcher { contract_address: data_store.contract_address },
+        IEventEmitterDispatcher { contract_address: event_emitter.contract_address },
+        IWithdrawalVaultDispatcher { contract_address: withdrawal_vault.contract_address },
+        key,
+        keeper,
+        100000_u256,
+        'TEST_CANCELLATION',
+        reason_bytes
+    );
+}
+
+#[test]
+fn test_swap() {
+    let (data_store, event_emitter, market_token, oracle, withdrawal_vault) = deploy_contracts();
+
+    // Set up test data
+    let key = 0x123;
+    let ui_fee_receiver = contract_address_const::<0x203>();
+    let min_oracle_block_numbers: Array<u64> = array![2000000_u64, 120000_u64, 100000_u64];
+    let min_oracle_block_numbers: Array<u64> = array![20000000_u64, 12000000_u64, 1000000_u64];
+    let keeper = contract_address_const::<0x300>();
+    let some_token = contract_address_const::<0x400>();
+    let token_in = contract_address_const::<0x200>();
+    let receiver = contract_address_const::<0x500>();
+    let ui_fee_receiver = contract_address_const::<0x600>();
+    let amount_in: u256 = 100000000000_u256;
+
+    // create execute withdrawal paramas
+    let params = ExecuteWithdrawalParams{
+        data_store: IDataStoreDispatcher{contract_address: data_store.contract_address},
+        event_emitter: IEventEmitterDispatcher{contract_address: event_emitter.contract_address},
+        withdrawal_vault: IWithdrawalVaultDispatcher{contract_address: withdrawal_vault.contract_address},
+        oracle: IOracleDispatcher{contract_address: oracle.contract_address},
+        key,
+        min_oracle_block_numbers,
+        max_oracle_block_numbers,
+        keeper,
+        starting_gas: 1000000000000_u256,
+    };
+    // create market data
+    let market = Market {
+        market_token: market_token.contract_address,
+        index_token: some_token,
+        long_token: some_token,
+        short_token: some_token,
+    };
+    
+    let swap_path = ArrayTrait::<ContractAddress>::new().span32();
+    let (output_token, output_amount) = swap(
+        @params,
+        market,
+        token_in,
+        amount_in,
+        swap_path,
+        min_output_amount: 100000000000_u256,
+        receiver,
+        ui_fee_receiver,
+    );
+
+    assert!(output_token == token_in, 'invalid token');
+    assert!(output_amount == amount_in, 'invalid amount');
+}

--- a/tests/withdrawal/test_withdrawal_vault.cairo
+++ b/tests/withdrawal/test_withdrawal_vault.cairo
@@ -1,0 +1,188 @@
+use core::traits::TryInto;
+use starknet::{ContractAddress, contract_address_const};
+use array::ArrayTrait;
+use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank};
+use satoru::data::data_store::{IDataStoreDispatcher, IDataStoreDispatcherTrait};
+use satoru::role::role_store::{IRoleStoreDispatcher, IRoleStoreDispatcherTrait};
+use satoru::withdrawal::withdrawal_vault::{IWithdrawalVaultDispatcher, IWithdrawalVaultDispatcherTrait};
+
+fn OWNER() -> ContractAddress{
+    contract_address_const::<1>()
+}
+const TOKEN_AMOUNT: u256 = 1000_u256;
+
+
+// mock ERC20
+#[starknet::interface]
+trait IERC20<T> {
+    fn transfer(ref self: T, recipient: ContractAddress, amount: u256) -> bool;
+    fn balance_of(self: @T, account: ContractAddress) -> u256;
+    fn transfer_from(
+        ref self: T, sender: ContractAddress, recipient: ContractAddress, amount: u256
+    ) -> bool;
+}
+
+#[starknet::contract]
+mod MockERC20 {
+    use starknet::{ContractAddress, get_caller_address};
+    use core::zeroable::Zeroable;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess, Map, StoragePathEntry};
+    
+
+    #[storage]
+    struct Storage {
+        balances: Map<ContractAddress, u256>,
+        total_supply: u256,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, initial_supply: u256, owner: ContractAddress) {
+        self.total_supply.write(initial_supply);
+        self.balances.write(owner, initial_supply);
+    }
+
+    #[abi(embed_v0)]
+    impl IERC20Impl of super::IERC20<ContractState> {
+        fn transfer(ref self: ContractState, recipient: ContractAddress, amount: u256) -> bool {
+            let sender = get_caller_address();
+            self.balances.write(sender, self.balances.read(sender) - amount);
+            self.balances.write(recipient, self.balances.read(recipient) + amount);
+            true
+        }
+        fn balance_of(self: @ContractState, account: ContractAddress) -> u256 {
+            self.balances.read(account)
+        }
+
+        fn transfer_from(
+            ref self: ContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+        ) -> bool {
+            self.balances.write(sender, self.balances.read(sender) - amount);
+            self.balances.write(recipient, self.balances.read(recipient) + amount);
+            true
+        }
+    }
+}
+
+fn deploy_mock_contracts() -> (IDataStoreDispatcher, IRoleStoreDispatcher, IERC20Dispatcher, IWithdrawalVaultDispatcher) {
+    // Deploy contracts and mock contract
+    let role_store_class = declare('RoleStore');
+    let role_store_address = role_store_class.deploy(@ArrayTrait::new()).unwrap();
+    
+    let data_store = declare('DataStore');
+    let data_store_address = data_store.deploy(@array![role_store_address.into()]).unwrap();
+
+    let withdrawal_vault = declare('WithdrawalVault');
+    let withdrawal_vault_address = withdrawal_vault.deploy(@array![data_store_address.into(),role_store_address.into(), ]).unwrap();
+
+    let mock_erc20 = declare('MockERC20');
+    let mut calldata: Array<felt252> = array![withdrawal_vault_address.into(), TOKEN_AMOUNT.try_into().unwrap()];
+    let mock_erc20_address = mock_erc20.deploy(@calldata).unwrap();
+
+    let data_store = IDataStoreDispatcher { contract_address: data_store_address };
+    let role_store = IRoleStoreDispatcher { contract_address: role_store_address };
+    let mock_erc20 = IERC20Dispatcher { contract_address: mock_erc20_address };
+    let withdrawal_vault = IWithdrawalVaultDispatcher { contract_address: withdrawal_vault_address };
+
+    (data_store, role_store, mock_erc20, withdrawal_vault)
+}
+
+
+
+#[test]
+fn test_initialize() {
+    let (data_store_dispatcher, role_store_dispatcher, _, withdrawal_vault_dispatcher ) = deploy_mock_contracts();
+    start_prank(OWNER(), withdrawal_vault_dispatcher.contract_address);
+    withdrawal_vault_dispatcher.initialize(
+        data_store_dispatcher.contract_address,
+        role_store_dispatcher.contract_address
+    );
+    stop_prank(withdrawal_vault_dispatcher.contract_address);
+    // The initialize function mostly sets up the StrictBank, which we can't directly test
+    // but we can verify that the contract doesn't revert
+    assert(true, 'initialization should succeed');
+}
+
+#[test]
+fn test_transfer_out() {
+    // Test withdrawal vault transfer out function
+    let (data_store_dispatcher, role_store_dispatcher, erc20_dispatcher, withdrawal_vault_dispatcher ) = deploy_mock_contracts();
+    let sender = OWNER();
+    let receiver = contract_address_const::<0x456>();
+
+    let token_addr = erc20_dispatcher.contract_address;
+    let amount: u256 = 500_u256;
+    // initialize Vault
+    start_prank(OWNER(), withdrawal_vault_dispatcher.contract_address);
+    withdrawal_vault_dispatcher.initialize(
+        data_store_dispatcher.contract_address,
+        role_store_dispatcher.contract_address
+    );
+    stop_prank(withdrawal_vault_dispatcher.contract_address);
+    
+    // Call transfer out function
+    start_prank(sender, withdrawal_vault_dispatcher.contract_address);
+    // Transfers the token from the withdrawal vault to the receiver
+    // Initially, the withdrawal vault has all the total supply of the token.
+    // This was done during the deployment.
+    // refer to the deploy_mock_contracts() function for more info. 
+    withdrawal_vault_dispatcher.transfer_out(
+        sender,
+        token_addr,
+        receiver,
+        amount
+    );
+    stop_prank(withdrawal_vault_dispatcher.contract_address);
+    // check the balance of the receiver.
+    assert(erc20_dispatcher.balance_of(receiver) == amount, 'Invalid balance');
+}
+
+#[test]
+fn test_record_transfer_in() {
+    // Test withdrawal vault record transfer in function
+    let (data_store_dispatcher, role_store_dispatcher, erc20_dispatcher, withdrawal_vault_dispatcher ) = deploy_mock_contracts();
+    let token_addr = erc20_dispatcher.contract_address;
+    // initialize Vault. needed to access the other functions
+    start_prank(OWNER(), withdrawal_vault_dispatcher.contract_address);
+    withdrawal_vault_dispatcher.initialize(
+        data_store_dispatcher.contract_address,
+        role_store_dispatcher.contract_address
+    );
+    stop_prank(withdrawal_vault_dispatcher.contract_address);
+
+    // call the record_transfer_in function
+    start_prank(OWNER(), withdrawal_vault_dispatcher.contract_address);
+    let recorded_amount = withdrawal_vault_dispatcher.record_transfer_in(
+        token_addr
+    );
+    stop_prank(withdrawal_vault_dispatcher.contract_address);
+    // according to the logic, the StrickBank contract keeps the record of tokens
+    // as the amount token of the mockERC20 contract that the StrictBank contract has is zero,
+    // the recorded amount would be 0.
+    assert(recorded_amount == 0, 'recorded amount should return 0');
+    
+}
+    
+#[test]
+fn test_sync_token_balance() {
+    // Test withdrawal vault sync token balance function
+    // similar to the record_transfer_in function, just return next_balance
+    // instead of the next_balance - prev_balance
+    let (data_store_dispatcher, role_store_dispatcher, erc20_dispatcher, withdrawal_vault_dispatcher ) = deploy_mock_contracts();
+    let token_addr = erc20_dispatcher.contract_address;
+    // initialize Vault. needed to access the other functions
+    start_prank(OWNER(), withdrawal_vault_dispatcher.contract_address);
+    withdrawal_vault_dispatcher.initialize(
+        data_store_dispatcher.contract_address,
+        role_store_dispatcher.contract_address
+    );
+    stop_prank(withdrawal_vault_dispatcher.contract_address);
+    // call the record_transfer_in function
+    start_prank(OWNER(), withdrawal_vault_dispatcher.contract_address);
+    let recorded_amount = withdrawal_vault_dispatcher.sync_token_balance(
+        token_addr
+    );
+    stop_prank(withdrawal_vault_dispatcher.contract_address);
+    // the recorded amount would be 0 
+    // as StrickBank token balance of MockERC20 token is 0. 
+    assert(recorded_amount == 0, 'recorded amount should return 0');
+}

--- a/tests/withdrawal/test_withdrawal_vault.cairo
+++ b/tests/withdrawal/test_withdrawal_vault.cairo
@@ -26,12 +26,11 @@ trait IERC20<T> {
 mod MockERC20 {
     use starknet::{ContractAddress, get_caller_address};
     use core::zeroable::Zeroable;
-    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess, Map, StoragePathEntry};
     
 
     #[storage]
     struct Storage {
-        balances: Map<ContractAddress, u256>,
+        balances: LegacyMap<ContractAddress, u256>,
         total_supply: u256,
     }
 


### PR DESCRIPTION
## Summary

This PR introduces comprehensive unit tests for the withdrawal functionality, covering the following files:
- `withdrawal.cairo`
- `withdrawal_utils.cairo`
- `withdrawal_vault.cairo`

The tests are organized in the `gojo/tests/withdrawal/` folder and ensure the correctness of the withdrawal process, including creation, cancellation, and token transfers.

## Key Changes:
1. **Test Coverage:**
   - **`test_withdrawal.cairo`:** 
     - Added `test_default_withdrawal` to verify the default state of a withdrawal.
   - **`test_withdrawal_utils.cairo`:**
     - Implemented `test_create_withdrawal_success` to validate successful withdrawal creation.
     - Added `test_create_withdrawal_insufficient_fee` to ensure the function panics when fees are insufficient.
     - Included `test_cancel_withdrawal` to test withdrawal cancellation.
     - Added `test_cancel_nonexistent_withdrawal` to verify handling of non-existent withdrawals.
     - Implemented `test_swap` to validate token swap functionality.
   - **`test_withdrawal_vault.cairo`:**
     - Added `test_initialize` to verify the initialization of the withdrawal vault.
     - Implemented `test_transfer_out` to test token transfers from the vault.
     - Included `test_record_transfer_in` to validate recording of token transfers.
     - Added `test_sync_token_balance` to test token balance synchronization.

2. **Mock Contracts:**
   - Deployed mock contracts (`MockERC20`) to simulate real-world interactions and ensure isolated testing.

3. **Assertions:**
   - Added assertions to validate contract states, ensuring that withdrawals are created, canceled, and transferred correctly.

## Acceptance Criteria:
- All unit tests are implemented and passing.
- Tests cover edge cases, such as insufficient fees and non-existent withdrawals.
- Mock contracts are used to isolate and validate functionality.


This PR ensures robust testing of the withdrawal functionality, improving code reliability and maintainability.

Closes #15 